### PR TITLE
Use pretty_generate in JSON Formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Do not serialize Messages::Hook#tag_expression if it is empty.
   ([PR#1579](https://github.com/cucumber/cucumber-ruby/pull/1579))
+  
+- JSON Formatter uses "pretty" output format
 
 ### Changed
 

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -81,7 +81,7 @@ module Cucumber
       end
 
       def on_test_run_finished(_event)
-        @io.write(JSON.generate(@feature_hashes, pretty: true))
+        @io.write(JSON.pretty_generate(@feature_hashes))
       end
 
       def attach(src, mime_type)


### PR DESCRIPTION
# Description

With the change to the JSON class, passing pretty as a parameter no longer does anything. `pretty_generate` should be called for the desired output.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
